### PR TITLE
Fix null reference in TraderKind property

### DIFF
--- a/1.5/Source/FactionColonies/worldobjects/WorldSettlementFC.cs
+++ b/1.5/Source/FactionColonies/worldobjects/WorldSettlementFC.cs
@@ -77,7 +77,7 @@ namespace FactionColonies
 
         public new float TradePriceImprovementOffsetForPlayer => trader?.TradePriceImprovementOffsetForPlayer ?? 0.0f;
 
-        public new TradeCurrency TradeCurrency => TraderKind.tradeCurrency;
+        public new TradeCurrency TradeCurrency => TraderKind?.tradeCurrency ?? TradeCurrency.Silver;
 
         public new bool EverVisited => trader.EverVisited;
 

--- a/1.5/Source/FactionColonies/worldobjects/WorldSettlementTraderTracker.cs
+++ b/1.5/Source/FactionColonies/worldobjects/WorldSettlementTraderTracker.cs
@@ -80,7 +80,12 @@ namespace FactionColonies
         {
             get
             {
-                return BaseTraderKinds.Any() ? BaseTraderKinds[Mathf.Abs(settlement.HashOffset()) % BaseTraderKinds.Count] : null;
+                if (BaseTraderKinds == null || !BaseTraderKinds.Any())
+                {
+                    Log.Error("BaseTraderKinds is null or empty.");
+                    return null;
+                }
+                return BaseTraderKinds[Mathf.Abs(settlement.HashOffset()) % BaseTraderKinds.Count];
             }
         }
 


### PR DESCRIPTION
Fix the null reference error in the Empire mod's trading system.

* Add a null check for the `TraderKind` property in `WorldSettlementTraderTracker` class.
* Handle the case where `BaseTraderKinds` is empty or null in `TraderKind` property.
* Log an error message if `BaseTraderKinds` is null or empty.
* Modify the `TradeCurrency` property in `WorldSettlementFC` class to handle null `TraderKind`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Kattalassien/Empire-1_5-Continued-/pull/1?shareId=8b043f34-5800-4bb1-930b-863e694e61e3).